### PR TITLE
Fetch from config object instead of process.env

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Insomnia Plugin - Systemenv
+# Insomnia Plugin - dotenv
 
 ## System Environment Variable
 
-Fetch data from the system variable.
+Fetch data from a .env file.
 
 ### Installation:
 

--- a/index.js
+++ b/index.js
@@ -18,18 +18,22 @@ module.exports.templateTags = [
         type: 'string'
       }
     ],
-    run(context, path, sysvar) {
+    run(context, path, varName) {
       fs.stat(path, function(err) {
         if (err && err.code === 'ENOENT')
           console.log('File or directory not found');
       });
 
-      dotenv.config({ path: path });
-      if (process.env[sysvar] === undefined) {
+      const config = dotenv.config({ path: path });
+      if (!config || config.error) {
+        throw new Error('Unexpected error occured when parsing the config file', config.error);
+      }
+      
+      if (config.parsed[varName] === undefined) {
         throw new Error('Variable not found!');
       }
 
-      return process.env[sysvar];
+      return config.parsed[varName];
     }
   }
 ];


### PR DESCRIPTION
`dotenv.config` returns a parsed object containing all env variables. While testing, fetching from `process.env` seemed to not work as the Insomnia environment changed.

See demo workspace here to test with.
[![Run in Insomnia}](https://insomnia.rest/images/run.svg)](https://insomnia.rest/run/?label=Example%20dotenv%20consmption&uri=https%3A%2F%2Fgist.githubusercontent.com%2Fdevelohpanda%2F5afb92631d9a23953bc22ad1ea9932bd%2Fraw%2F67561fcbb28c57434d9f303b78776fa0cb392802%2Finsomnia.json)

Note you will need to direct the `envFilePath` variable at env files on your file system. [These](https://gist.github.com/develohpanda/5afb92631d9a23953bc22ad1ea9932bd) are the .env files I have on my file system for testing.

Using `process.env`, note values do not change:
![2020-09-11 07 40 49](https://user-images.githubusercontent.com/4312346/92793067-32f12d80-f402-11ea-935b-2b4757ac1b9f.gif)

Using config object:
![2020-09-11 07 42 36](https://user-images.githubusercontent.com/4312346/92793364-6f248e00-f402-11ea-8dfe-5ccf938b8e64.gif)
